### PR TITLE
Fix bug "TypeError: expected str, bytes or os.PathLike object, not Im…

### DIFF
--- a/src/images/models.py
+++ b/src/images/models.py
@@ -14,7 +14,7 @@ class Image(models.Model):
 
     def save(self, *args, **kwargs):
         try:
-            img = load_img(self.picture, target_size=(299,299))
+            img = load_img(self.picture.path, target_size=(299,299))
             img_arry = img_to_array(img)
             to_pred = np.expand_dims(img_arry, axis=0) #(1, 299, 299, 3)
             prep = preprocess_input(to_pred)


### PR DESCRIPTION
There is a bug when you run this, and it is "TypeError: expected str, bytes or os.PathLike object, not ImageFieldFile",
switching 
from:
`img = load_img(self.picture, target_size=(299,299))`
to:
`img = load_img(self.picture.path, target_size=(299,299))`

fixes the issue